### PR TITLE
rough working html parser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,7 @@ edition = "2018"
 
 [dependencies]
 nom = "6"
+tracing = "0.1.22"
+
+[dev-dependencies]
+tracing-subscriber = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ tracing = "0.1.22"
 
 [dev-dependencies]
 tracing-subscriber = "0.2"
+structopt = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [dependencies]
 nom = "6"
 tracing = "0.1.22"
+regex = "1"
 
 [dev-dependencies]
 tracing-subscriber = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,4 @@ authors = ["Henry de Valence <hdevalence@hdevalence.ca>"]
 edition = "2018"
 
 [dependencies]
+nom = "6"

--- a/examples/dump.rs
+++ b/examples/dump.rs
@@ -1,0 +1,42 @@
+use std::path::PathBuf;
+use structopt::StructOpt;
+use tracing_subscriber::EnvFilter;
+
+#[derive(Debug, StructOpt)]
+#[structopt(name = "dump", about = "Dump parsed HTML or CSS as an AST.")]
+struct Opts {
+    #[structopt(long = "log", env = "RUST_LOG")]
+    log: Option<EnvFilter>,
+
+    #[structopt(subcommand)]
+    kind: Kind,
+}
+
+#[derive(Debug, StructOpt)]
+enum Kind {
+    Html {
+        #[structopt(name = "file", parse(from_os_str))]
+        file: PathBuf,
+    },
+    Css {
+        #[structopt(name = "FILE", parse(from_os_str))]
+        file: PathBuf,
+    },
+}
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let opts = Opts::from_args();
+    if let Some(log) = opts.log {
+        tracing_subscriber::fmt().with_env_filter(log).init();
+    }
+    match opts.kind {
+        Kind::Html { file } => {
+            let s = std::fs::read_to_string(file)?;
+            match s.parse::<text_tree::content_tree::Node>() {
+                Ok(node) => println!("{:#?}", node),
+                Err(e) => eprintln!("parse error: {}", e),
+            }
+        }
+        Kind::Css { file: _ } => todo!("eliza needs to implement this!"),
+    }
+    Ok(())
+}

--- a/examples/dump.rs
+++ b/examples/dump.rs
@@ -32,7 +32,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         Kind::Html { file } => {
             let s = std::fs::read_to_string(file)?;
             match s.parse::<text_tree::content_tree::Node>() {
-                Ok(node) => println!("{:#?}", node),
+                Ok(node) => println!("{}", node),
                 Err(e) => eprintln!("parse error: {}", e),
             }
         }

--- a/src/content_tree/mod.rs
+++ b/src/content_tree/mod.rs
@@ -1,4 +1,5 @@
 use std::collections::HashSet;
+pub mod parse;
 
 #[derive(Debug)]
 pub struct Node {
@@ -12,7 +13,7 @@ pub enum NodeData {
     Element(ElementData),
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct ElementData {
     //pub(super) node_type: Option<String>,
     pub(super) id: Option<String>,

--- a/src/content_tree/mod.rs
+++ b/src/content_tree/mod.rs
@@ -20,11 +20,14 @@ pub struct ElementData {
     pub(super) classes: HashSet<String>,
 }
 
-impl From<String> for Node {
-    fn from(s: String) -> Node {
+impl<T> From<T> for Node
+where
+    String: From<T>,
+{
+    fn from(s: T) -> Node {
         Node {
             children: Vec::new(),
-            node_data: NodeData::Text(s),
+            node_data: NodeData::Text(String::from(s)),
         }
     }
 }

--- a/src/content_tree/mod.rs
+++ b/src/content_tree/mod.rs
@@ -32,6 +32,18 @@ where
     }
 }
 
+impl std::str::FromStr for Node {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        use nom::Finish;
+        match parse::document(s).finish() {
+            Ok((_remaining, node)) => Ok(node),
+            Err(e) => Err(nom::error::convert_error(s, e)),
+        }
+    }
+}
+
 impl Node {
     pub fn new(children: Vec<Node>, id: Option<String>, classes: HashSet<String>) -> Node {
         Node {

--- a/src/content_tree/mod.rs
+++ b/src/content_tree/mod.rs
@@ -1,4 +1,5 @@
 use std::collections::HashSet;
+use std::fmt;
 pub mod parse;
 
 #[derive(Debug, PartialEq, Eq)]
@@ -60,5 +61,30 @@ impl Node {
             NodeData::Text(ref s) => Some(s),
             NodeData::Element(_) => None,
         }
+    }
+}
+
+impl fmt::Display for Node {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fn fmt_at(node: &Node, f: &mut fmt::Formatter<'_>, i: usize) -> fmt::Result {
+            let indent = std::iter::repeat("  ").take(i).collect::<String>(); // todo(eliza): ew lol
+            match node.node_data {
+                NodeData::Text(ref t) => writeln!(f, "{}{:?}", indent, t)?,
+                NodeData::Element(ElementData {
+                    ref id,
+                    ref classes,
+                }) => {
+                    writeln!(f, "{}<tag id={:?} class={:?}>", indent, id, classes)?;
+
+                    for child in &node.children {
+                        fmt_at(child, f, i + 1)?;
+                    }
+
+                    writeln!(f, "{}</tag>", indent)?;
+                }
+            }
+            Ok(())
+        }
+        fmt_at(self, f, 0)
     }
 }

--- a/src/content_tree/mod.rs
+++ b/src/content_tree/mod.rs
@@ -3,8 +3,8 @@ pub mod parse;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Node {
-    pub(super) children: Vec<Node>,
     pub(super) node_data: NodeData,
+    pub(super) children: Vec<Node>,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -38,7 +38,10 @@ impl std::str::FromStr for Node {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use nom::Finish;
         match parse::document(s).finish() {
-            Ok((_remaining, node)) => Ok(node),
+            Ok((remaining, node)) => {
+                dbg!(remaining);
+                Ok(node)
+            }
             Err(e) => Err(nom::error::convert_error(s, e)),
         }
     }

--- a/src/content_tree/mod.rs
+++ b/src/content_tree/mod.rs
@@ -1,13 +1,13 @@
 use std::collections::HashSet;
 pub mod parse;
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Node {
     pub(super) children: Vec<Node>,
     pub(super) node_data: NodeData,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum NodeData {
     Text(String),
     Element(ElementData),

--- a/src/content_tree/parse.rs
+++ b/src/content_tree/parse.rs
@@ -1,0 +1,45 @@
+use super::*;
+use nom::error::VerboseError;
+use nom::{
+    branch::*, bytes::complete::*, character::complete::*, combinator::*, multi::*, sequence::*,
+};
+
+/// Use `nom`'s verbose errors for pretty-printing.
+pub type IResult<I, T> = nom::IResult<I, T, VerboseError<I>>;
+
+fn identifier(input: &str) -> IResult<&str, &str> {
+    recognize(pair(
+        alt((alpha1, tag("_"), tag(":"))),
+        many0(alt((alphanumeric1, tag("_"), tag(":"), tag(".")))),
+    ))(input)
+}
+
+fn open_tag(input: &str) -> IResult<&str, ElementData> {
+    let mut parse_open_tag = delimited(tag("<"), identifier, tag(">"));
+    let (remaining, name) = parse_open_tag(input)?;
+    let mut classes = HashSet::new();
+    classes.insert(String::from(name));
+    Ok((
+        remaining,
+        ElementData {
+            // TODO(eliza)
+            id: None,
+            classes,
+        },
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn simple_open_tag() {
+        let open = "<a>";
+        let (remaining, parsed) = dbg!(open_tag(open)).expect("it should parse");
+
+        let mut classes = HashSet::new();
+        classes.insert(String::from("a"));
+        assert_eq!(parsed, ElementData { classes, id: None });
+        assert_eq!(remaining, "");
+    }
+}

--- a/src/content_tree/parse.rs
+++ b/src/content_tree/parse.rs
@@ -14,19 +14,49 @@ fn identifier(input: &str) -> IResult<&str, &str> {
     ))(input)
 }
 
+fn attribute_value(input: &str) -> IResult<&str, &str> {
+    preceded(tag("="), delimited(tag("\""), take_until("\""), tag("\"")))(input)
+}
+
+fn named_attribute<'a>(name: &'static str) -> impl FnMut(&'a str) -> IResult<&'a str, &'a str> {
+    preceded(tag(name), attribute_value)
+}
+
+fn any_attribute(input: &str) -> IResult<&str, (&str, &str)> {
+    pair(identifier, attribute_value)(input)
+}
+
 fn open_tag(input: &str) -> IResult<&str, ElementData> {
-    let mut parse_open_tag = delimited(tag("<"), identifier, tag(">"));
-    let (remaining, name) = parse_open_tag(input)?;
+    let (remaining, (tag_name, attrs)) = delimited(
+        tag("<"),
+        pair(
+            identifier,
+            opt(preceded(
+                multispace1,
+                separated_list0(multispace1, any_attribute),
+            )),
+        ),
+        tag(">"),
+    )(input)?;
+
     let mut classes = HashSet::new();
-    classes.insert(String::from(name));
-    Ok((
-        remaining,
-        ElementData {
-            // TODO(eliza)
-            id: None,
-            classes,
-        },
-    ))
+    let mut id = None;
+    for (name, val) in attrs.into_iter().flat_map(IntoIterator::into_iter) {
+        match name {
+            "class" => {
+                classes = val.split(' ').map(String::from).collect();
+            }
+            "id" => {
+                id = Some(val.to_string());
+            }
+            "style" => todo!("style attributes should probably 'work'..."),
+            _ => {
+                // Skip other attributes for now...
+            }
+        }
+    }
+    classes.insert(tag_name.to_string());
+    Ok((remaining, ElementData { id, classes }))
 }
 
 #[cfg(test)]
@@ -35,11 +65,77 @@ mod tests {
     #[test]
     fn simple_open_tag() {
         let open = "<a>";
-        let (remaining, parsed) = dbg!(open_tag(open)).expect("it should parse");
+        let (remaining, parsed) = dbg!(open_tag(open))
+            .map_err(|e| e.to_string())
+            .expect("it should parse");
 
         let mut classes = HashSet::new();
         classes.insert(String::from("a"));
         assert_eq!(parsed, ElementData { classes, id: None });
+        assert_eq!(remaining, "");
+    }
+
+    #[test]
+    fn open_tag_with_ignored_attrs() {
+        let open = "<a href=\"my cool website\">";
+        let (remaining, parsed) = dbg!(open_tag(open))
+            .map_err(|e| e.to_string())
+            .expect("it should parse");
+
+        let mut classes = HashSet::new();
+        classes.insert(String::from("a"));
+        assert_eq!(parsed, ElementData { classes, id: None });
+        assert_eq!(remaining, "");
+    }
+
+    #[test]
+    fn open_tag_with_classes() {
+        let open = "<a class=\"foo bar baz\">";
+        let (remaining, parsed) = dbg!(open_tag(open))
+            .map_err(|e| e.to_string())
+            .expect("it should parse");
+
+        let classes = vec!["a", "foo", "bar", "baz"]
+            .into_iter()
+            .map(String::from)
+            .collect();
+        assert_eq!(parsed, ElementData { classes, id: None });
+        assert_eq!(remaining, "");
+    }
+
+    #[test]
+    fn open_tag_with_classes_and_attrs() {
+        let open = "<a href=\"my website\" class=\"foo bar baz\" something=\"lol\">";
+        let (remaining, parsed) = dbg!(open_tag(open))
+            .map_err(|e| e.to_string())
+            .expect("it should parse");
+
+        let classes = vec!["a", "foo", "bar", "baz"]
+            .into_iter()
+            .map(String::from)
+            .collect();
+        assert_eq!(parsed, ElementData { classes, id: None });
+        assert_eq!(remaining, "");
+    }
+
+    #[test]
+    fn open_tag_with_classes_and_id() {
+        let open = "<a href=\"my website\" class=\"foo bar baz\" id=\"cool\">";
+        let (remaining, parsed) = dbg!(open_tag(open))
+            .map_err(|e| e.to_string())
+            .expect("it should parse");
+
+        let classes = vec!["a", "foo", "bar", "baz"]
+            .into_iter()
+            .map(String::from)
+            .collect();
+        assert_eq!(
+            parsed,
+            ElementData {
+                classes,
+                id: Some("cool".to_string())
+            }
+        );
         assert_eq!(remaining, "");
     }
 }


### PR DESCRIPTION
this branch adds a quick and kinda messy HTML parser, written
using `nom`. i also included an example that parses an HTML
file and dumps the parsed representation, to show that it works.